### PR TITLE
Khalid/sdlc 29555

### DIFF
--- a/helm/nats-streaming-operator/templates/deployment.yaml
+++ b/helm/nats-streaming-operator/templates/deployment.yaml
@@ -18,13 +18,6 @@ spec:
     matchLabels:
       app: {{ template "nats.name" . }}
       release: {{ .Release.Name }}
-  strategy:
-    type: {{ .Values.updateStrategy }}
-    {{- if eq .Values.updateStrategy "RollingUpdate" }}
-    rollingUpdate:
-      maxSurge: {{ .Values.rollingUpdateMaxSurge }}
-      maxUnavailable: {{ .Values.rollingUpdateMaxUnavailable }}
-    {{- end }}
   template:
     metadata:
       labels:

--- a/helm/nats-streaming-operator/values.yaml
+++ b/helm/nats-streaming-operator/values.yaml
@@ -8,7 +8,7 @@ cluster:
   enabled: true
 
   # Name of the NATS Streaming Cluster
-  name: nats-streaming-cluster-test
+  name: nats-streaming-cluster
 
   # Version of the NATS Streaming Cluster to deploy
   version: 0.17.0
@@ -17,7 +17,7 @@ cluster:
   size: 3
 
   # NATS Cluster service name
-  natsSvc: nats-cluster-test
+  natsSvc: nats-cluster
 
   config:
     debug: true

--- a/helm/nats-streaming-operator/values.yaml
+++ b/helm/nats-streaming-operator/values.yaml
@@ -1,14 +1,14 @@
 ## Specify if RBAC authorization is enabled.
 ## ref: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
 ##
-rbacEnabled: false
+rbacEnabled: true
 
 cluster:
   # Deploy a NATS Streaming Cluster with the operator
   enabled: true
 
   # Name of the NATS Streaming Cluster
-  name: nats-streaming-cluster
+  name: nats-streaming-cluster-test
 
   # Version of the NATS Streaming Cluster to deploy
   version: 0.17.0
@@ -17,7 +17,7 @@ cluster:
   size: 3
 
   # NATS Cluster service name
-  natsSvc: "nats-cluster"
+  natsSvc: nats-cluster-test
 
   config:
     debug: true
@@ -27,7 +27,7 @@ cluster:
   metrics:
     enabled: true
     image: synadia/prometheus-nats-exporter
-    version: "0.2.0"
+    version: "0.6.0"
 
 image:
   registry: docker.io
@@ -83,15 +83,9 @@ podAnnotations: {}
 ##
 podLabels: {}
 
-## Update strategy, can be set to RollingUpdate or OnDelete by default.
-## https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#updating-statefulsets
-updateStrategy: RollingUpdate
-
 ## Partition update strategy
 ## https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#partitions
 # rollingUpdatePartition:
-rollingUpdateMaxSurge: 25%
-rollingUpdateMaxUnavailable: 25%
 
 ## Configure resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
@@ -107,14 +101,14 @@ resources: {}
 ## Configure extra options for liveness and readiness probes
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes)
 livenessProbe:
-  enabled: true
+  enabled: false
   initialDelaySeconds: 30
   periodSeconds: 10
   timeoutSeconds: 5
   failureThreshold: 6
   successThreshold: 1
 readinessProbe:
-  enabled: true
+  enabled: false
   initialDelaySeconds: 5
   periodSeconds: 10
   timeoutSeconds: 5


### PR DESCRIPTION
Why?

As part of https://jira.cogitocorp.us/browse/SDLC-29555 I evaluated the NATS and NATS streaming operators and installed it in nats-test namespace of arn:aws:eks:us-east-1:935347465797:cluster/dev .

Please don't merge yet. There are few configs that are missing to make it match the state installed in the dev cluster. The installation is in fault-tolerant mode which this Helm chart does not support.